### PR TITLE
docs: align copilot-instructions with CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -292,7 +292,7 @@ A GitHub Actions workflow (`.github/workflows/pr-title.yml`) automatically valid
 
 Use `!` after the type/scope or include `BREAKING CHANGE:` in the PR body for breaking changes, which trigger a major version bump.
 
-For more details, see the <a>PR template</a> and [Contributing Guide](../CONTRIBUTING.md).
+For more details, see the <a href="../.github/pull_request_template.md">PR template</a> and [Contributing Guide](../CONTRIBUTING.md).
 
 ## Testing Guidelines
 


### PR DESCRIPTION
## Summary

Brings `.github/copilot-instructions.md` in sync with the authoritative `CLAUDE.md` file.

## Changes

- **Fix source file names**: `evaluation.rs` → `evaluator.rs`; add `types.rs`, `error.rs`
- **Remove phantom CLI**: No `src/bin/` or `cli_tests.rs` exists — removed all references
- **Correct Python integration**: Python uses PyO3 native bindings, not WASM/wasmer
- **Fix WASM build command**: Add `--no-default-features --lib`
- **Fix optimization note**: `opt-level=2` for speed (not `z` for size)
- **Add full development workflow**: Issue First, Work in Worktrees, Sub-Agents, Workflow Summary
- **Add Deep-Dive References table**: Links to ARCHITECTURE.md, CONTRIBUTING.md, BENCHMARKS.md, etc.
- **Update operators section**: `starts_with`/`ends_with` are from datalogic-rs, not separate files
- **Update test docs**: Reflect actual test files (`gherkin_tests.rs`, `metadata_merging_tests.rs`); remove `cli_tests.rs`
- **Add PyO3** to Related Technologies