### PR TITLE
ci: add required CI gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,3 +289,30 @@ jobs:
           path: |
             java/target/*.jar
           retention-days: 30
+
+  ci-success:
+    name: CI
+    if: always()
+    needs:
+      - test
+      - clippy
+      - fmt
+      - build-wasm
+      - test-go
+      - test-js
+      - test-dotnet
+      - test-python-native
+      - test-python-wasm
+      - test-java
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs passed
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          for result in $results; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "One or more CI jobs failed or were cancelled: $results"
+              exit 1
+            fi
+          done
+          echo "All CI jobs passed: $results"


### PR DESCRIPTION
## Summary

Adds a `ci-success` gate job (displayed as **CI** in GitHub checks) that fans in all existing CI jobs. This gives a single, stable check name to configure in branch protection rules.

## How it works

The `ci-success` job:
- Has `if: always()` so it always runs regardless of other job outcomes
- Lists every job in `needs`
- Fails if any dependency result is `failure` or `cancelled`
- Succeeds only when all jobs pass

## Branch protection setup

After merging, go to **Settings → Branches → Branch protection rules** for `main` and add **`CI`** as a required status check. This single rule gates all jobs in the workflow.

## Jobs covered

`test` · `clippy` · `fmt` · `build-wasm` · `test-go` · `test-js` · `test-dotnet` · `test-python-native` · `test-python-wasm` · `test-java`