### PR TITLE
test(java): adopt flagd-api-testkit compliance suite

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,7 +31,35 @@
         <junit.version>5.14.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <jmh.version>1.37</jmh.version>
+        <flagd.api.testkit.version>0.2.1</flagd.api.testkit.version>
+        <cucumber.version>7.34.3</cucumber.version>
     </properties>
+
+    <!-- ===================== -->
+    <!-- Dependency management -->
+    <!-- ===================== -->
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Align every JUnit Platform artifact (incl. those pulled transitively by
+                 cucumber and the testkit) to one version to avoid a split classpath. -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Align every transitive cucumber artifact to one version. -->
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>${cucumber.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <!-- ===================== -->
     <!-- Dependencies -->
@@ -106,6 +134,32 @@
             <groupId>dev.openfeature.contrib.tools</groupId>
             <artifactId>flagd-api</artifactId>
             <version>0.1.0</version>
+        </dependency>
+
+        <!-- flagd-api-testkit: canonical Cucumber compliance suite for the Evaluator
+             interface. Bundles Gherkin features + flag configs from open-feature/test-harness. -->
+        <dependency>
+            <groupId>dev.openfeature.contrib.tools</groupId>
+            <artifactId>flagd-api-testkit</artifactId>
+            <version>${flagd.api.testkit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Cucumber + JUnit Platform Suite runtime required to run the testkit scenarios. -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-picocontainer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/java/src/main/java/dev/openfeature/flagd/evaluator/FlagEvaluator.java
+++ b/java/src/main/java/dev/openfeature/flagd/evaluator/FlagEvaluator.java
@@ -708,8 +708,16 @@ public class FlagEvaluator implements AutoCloseable, Evaluator {
             throw new TypeMismatch("expected String but got " + raw.getClass().getSimpleName());
         }
         if (type == Integer.class) {
+            if (raw instanceof Integer) {
+                return (T) raw;
+            }
+            // Accept other numeric types only when they have no fractional part and fit
+            // in an int; a genuinely fractional value (e.g. 2.5) is a type mismatch.
             if (raw instanceof Number) {
-                return (T) Integer.valueOf(((Number) raw).intValue());
+                double d = ((Number) raw).doubleValue();
+                if (d == (int) d) {
+                    return (T) Integer.valueOf((int) d);
+                }
             }
             throw new TypeMismatch("expected Integer but got " + raw.getClass().getSimpleName());
         }

--- a/java/src/main/java/dev/openfeature/flagd/evaluator/FlagEvaluator.java
+++ b/java/src/main/java/dev/openfeature/flagd/evaluator/FlagEvaluator.java
@@ -603,62 +603,135 @@ public class FlagEvaluator implements AutoCloseable, Evaluator {
 
     @Override
     public ProviderEvaluation<Boolean> resolveBooleanValue(String flagKey, Boolean defaultValue, EvaluationContext ctx) {
-        try {
-            return toProviderEvaluation(evaluateFlag(Boolean.class, flagKey, ctx), defaultValue);
-        } catch (EvaluatorException e) {
-            return errorEvaluation(defaultValue, e);
-        }
+        return resolveTyped(Boolean.class, flagKey, defaultValue, ctx);
     }
 
     @Override
     public ProviderEvaluation<String> resolveStringValue(String flagKey, String defaultValue, EvaluationContext ctx) {
-        try {
-            return toProviderEvaluation(evaluateFlag(String.class, flagKey, ctx), defaultValue);
-        } catch (EvaluatorException e) {
-            return errorEvaluation(defaultValue, e);
-        }
+        return resolveTyped(String.class, flagKey, defaultValue, ctx);
     }
 
     @Override
     public ProviderEvaluation<Integer> resolveIntegerValue(String flagKey, Integer defaultValue, EvaluationContext ctx) {
-        try {
-            return toProviderEvaluation(evaluateFlag(Integer.class, flagKey, ctx), defaultValue);
-        } catch (EvaluatorException e) {
-            return errorEvaluation(defaultValue, e);
-        }
+        return resolveTyped(Integer.class, flagKey, defaultValue, ctx);
     }
 
     @Override
     public ProviderEvaluation<Double> resolveDoubleValue(String flagKey, Double defaultValue, EvaluationContext ctx) {
-        try {
-            return toProviderEvaluation(evaluateFlag(Double.class, flagKey, ctx), defaultValue);
-        } catch (EvaluatorException e) {
-            return errorEvaluation(defaultValue, e);
-        }
+        return resolveTyped(Double.class, flagKey, defaultValue, ctx);
     }
 
     @Override
     public ProviderEvaluation<Value> resolveObjectValue(String flagKey, Value defaultValue, EvaluationContext ctx) {
+        return resolveTyped(Value.class, flagKey, defaultValue, ctx);
+    }
+
+    /**
+     * Evaluates a flag and maps the result onto a typed {@link ProviderEvaluation},
+     * validating and converting the resolved value to the requested type.
+     *
+     * <p>The WASM result carries an untyped value (deserialized as a plain Object), so
+     * type compatibility is checked here: a value that cannot be coerced to {@code type}
+     * yields a {@code TYPE_MISMATCH} error with the caller default, mirroring the flagd
+     * provider specification.
+     */
+    private <T> ProviderEvaluation<T> resolveTyped(
+            Class<T> type, String flagKey, T defaultValue, EvaluationContext ctx) {
+        final EvaluationResult<T> result;
         try {
-            return toProviderEvaluation(evaluateFlag(Value.class, flagKey, ctx), defaultValue);
+            result = evaluateFlag(type, flagKey, ctx);
         } catch (EvaluatorException e) {
             return errorEvaluation(defaultValue, e);
         }
-    }
 
-    private <T> ProviderEvaluation<T> toProviderEvaluation(EvaluationResult<T> result, T defaultValue) {
-        ProviderEvaluation.ProviderEvaluationBuilder<T> builder = ProviderEvaluation.<T>builder()
-                .value(result.getValue() != null ? result.getValue() : defaultValue)
-                .variant(result.getVariant())
-                .reason(result.getReason());
+        String reason = normalizeReason(result.getReason());
+
+        // Engine-reported error: return the caller default with the mapped error code.
         if (result.getErrorCode() != null) {
-            builder.errorCode(mapErrorCode(result.getErrorCode()))
+            ProviderEvaluation.ProviderEvaluationBuilder<T> builder = ProviderEvaluation.<T>builder()
+                    .value(defaultValue)
+                    .reason(reason != null ? reason : "ERROR")
+                    .errorCode(mapErrorCode(result.getErrorCode()))
                     .errorMessage(result.getErrorMessage());
+            if (result.getFlagMetadata() != null) {
+                builder.flagMetadata(result.getFlagMetadata());
+            }
+            return builder.build();
         }
+
+        // Validate/convert the resolved value to the requested type.
+        final T value;
+        try {
+            value = coerceValue(result.getValue(), type);
+        } catch (TypeMismatch e) {
+            return ProviderEvaluation.<T>builder()
+                    .value(defaultValue)
+                    .reason("ERROR")
+                    .errorCode(ErrorCode.TYPE_MISMATCH)
+                    .errorMessage(e.getMessage())
+                    .build();
+        }
+
+        ProviderEvaluation.ProviderEvaluationBuilder<T> builder = ProviderEvaluation.<T>builder()
+                .value(value != null ? value : defaultValue)
+                .variant(result.getVariant())
+                .reason(reason);
         if (result.getFlagMetadata() != null) {
             builder.flagMetadata(result.getFlagMetadata());
         }
         return builder.build();
+    }
+
+    /**
+     * Converts an untyped resolved value to the requested type, throwing {@link TypeMismatch}
+     * when the value is incompatible. Numbers are converted between Integer and Double (as the
+     * flagd spec allows); object values are wrapped as an SDK {@link Value}.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> T coerceValue(Object raw, Class<T> type) {
+        if (raw == null) {
+            return null;
+        }
+        if (type == Value.class) {
+            return (T) Value.objectToValue(raw);
+        }
+        if (type == Boolean.class) {
+            if (raw instanceof Boolean) {
+                return (T) raw;
+            }
+            throw new TypeMismatch("expected Boolean but got " + raw.getClass().getSimpleName());
+        }
+        if (type == String.class) {
+            if (raw instanceof String) {
+                return (T) raw;
+            }
+            throw new TypeMismatch("expected String but got " + raw.getClass().getSimpleName());
+        }
+        if (type == Integer.class) {
+            if (raw instanceof Number) {
+                return (T) Integer.valueOf(((Number) raw).intValue());
+            }
+            throw new TypeMismatch("expected Integer but got " + raw.getClass().getSimpleName());
+        }
+        if (type == Double.class) {
+            if (raw instanceof Number) {
+                return (T) Double.valueOf(((Number) raw).doubleValue());
+            }
+            throw new TypeMismatch("expected Double but got " + raw.getClass().getSimpleName());
+        }
+        return (T) raw;
+    }
+
+    /** Maps the engine's non-standard {@code FALLBACK} reason to the OpenFeature {@code DEFAULT}. */
+    private static String normalizeReason(String reason) {
+        return "FALLBACK".equals(reason) ? "DEFAULT" : reason;
+    }
+
+    /** Signals that a resolved value is not compatible with the requested type. */
+    private static final class TypeMismatch extends RuntimeException {
+        TypeMismatch(String message) {
+            super(message);
+        }
     }
 
     private <T> ProviderEvaluation<T> errorEvaluation(T defaultValue, EvaluatorException e) {

--- a/java/src/test/java/dev/openfeature/flagd/evaluator/e2e/FlagdEvaluatorComplianceTest.java
+++ b/java/src/test/java/dev/openfeature/flagd/evaluator/e2e/FlagdEvaluatorComplianceTest.java
@@ -1,0 +1,29 @@
+package dev.openfeature.flagd.evaluator.e2e;
+
+import dev.openfeature.contrib.tools.flagd.api.Evaluator;
+import dev.openfeature.contrib.tools.flagd.api.testkit.AbstractEvaluatorTest;
+import dev.openfeature.flagd.evaluator.FlagEvaluator;
+import org.junit.platform.suite.api.ExcludeTags;
+
+/**
+ * Compliance test suite running the bundled {@code flagd-api-testkit} Gherkin
+ * scenarios against the WASM-backed {@link FlagEvaluator}, which already implements
+ * the flagd-api {@link Evaluator} interface directly — no adapter required.
+ *
+ * <p>All Cucumber runner configuration is provided by {@link AbstractEvaluatorTest}.
+ * This class is discovered via Java SPI — see
+ * {@code src/test/resources/META-INF/services/dev.openfeature.contrib.tools.flagd.api.testkit.EvaluatorFactory}.
+ *
+ * <p>{@code fractional-v1} is excluded because the core implements the high-precision
+ * v2 bucketing algorithm; the v1 examples assert the legacy float-based results.
+ */
+@ExcludeTags("fractional-v1")
+public class FlagdEvaluatorComplianceTest extends AbstractEvaluatorTest {
+
+    @Override
+    public Evaluator create(String flagsJson) throws Exception {
+        FlagEvaluator evaluator = new FlagEvaluator();
+        evaluator.setFlags(flagsJson);
+        return evaluator;
+    }
+}

--- a/java/src/test/resources/META-INF/services/dev.openfeature.contrib.tools.flagd.api.testkit.EvaluatorFactory
+++ b/java/src/test/resources/META-INF/services/dev.openfeature.contrib.tools.flagd.api.testkit.EvaluatorFactory
@@ -1,0 +1,1 @@
+dev.openfeature.flagd.evaluator.e2e.FlagdEvaluatorComplianceTest


### PR DESCRIPTION
## Description

Adopts the canonical **flagd-api-testkit** (`dev.openfeature.contrib.tools:flagd-api-testkit:0.2.1`) compliance suite for the Java package, validating the WASM-backed evaluator against the same Gherkin scenarios every flagd in-process provider must pass.

Because `FlagEvaluator` already implements the flagd-api `Evaluator` interface, the suite runs against it directly — **no adapter required**. The testkit is discovered via the `EvaluatorFactory` SPI.

## Changes

**`test(java): adopt flagd-api-testkit compliance suite`**
- Add `flagd-api-testkit` + `cucumber-junit-platform-engine` + `cucumber-picocontainer` + `junit-platform-suite` as test-scoped deps, aligned via the JUnit and Cucumber BOMs (the project has no parent BOM, so a split JUnit Platform classpath otherwise causes `NoClassDefFoundError`).
- `FlagdEvaluatorComplianceTest extends AbstractEvaluatorTest`, registered via `META-INF/services`.
- Exclude `@fractional-v1`: the core implements high-precision v2 bucketing, so the legacy float-based v1 examples don't apply.

**`fix(java): make Evaluator interface spec-compliant`** — gaps surfaced by the suite, fixed in `FlagEvaluator`'s `Evaluator` methods:
- Return `TYPE_MISMATCH` when a resolved value is incompatible with the requested type (the WASM result carries an untyped value, so the check happens Java-side).
- Wrap object values as an SDK `Value` instead of a raw `Map`.
- Normalize the engine's non-standard `FALLBACK` reason to the OpenFeature `DEFAULT` reason.

## Testing

- [x] `./mvnw test` — **67/67** testkit compliance scenarios pass; existing `FlagEvaluatorTest` (19), `EvaluatorInterfaceTest` (11), `YamlLoadingTest`, comparison and jackson suites all remain green.

## Related

Addresses fork issue open-feature-forking/flagd-evaluator#116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
